### PR TITLE
Update continuous_coverage_and_quality_analysis.yml

### DIFF
--- a/.github/workflows/continuous_coverage_and_quality_analysis.yml
+++ b/.github/workflows/continuous_coverage_and_quality_analysis.yml
@@ -4,8 +4,6 @@ on:
   workflow_run:
     workflows: [ "Continuous building and testing" ]
     types: [ completed ]
-  push:
-  pull_request:
 
 jobs:
 


### PR DESCRIPTION
run only if Continuous building and testing is completed successfully. So no useless skip of workflow