### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/src/rest-api/calculator/views.py
+++ b/src/rest-api/calculator/views.py
@@ -34,5 +34,8 @@ class CalculatorAPIView(APIView):
                 
                 return Response({'result': str(result_value)}, status=status.HTTP_200_OK)
             except Exception as e:
-                return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.error("An error occurred while processing the request.", exc_info=True)
+                return Response({'error': "An internal error occurred."}, status=status.HTTP_400_BAD_REQUEST)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Potential fix for [https://github.com/Oz-NoXIII/calculator-cucumber-2025/security/code-scanning/5](https://github.com/Oz-NoXIII/calculator-cucumber-2025/security/code-scanning/5)

To fix the issue, we will replace the detailed exception message (`str(e)`) with a generic error message in the HTTP response. The detailed exception information will be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues.

- Modify the `except` block to log the exception details using Python's `logging` module.
- Replace the user-facing error message with a generic message like "An internal error occurred."


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
